### PR TITLE
Removed lines throwing errors upon compilation.

### DIFF
--- a/src/android/res/values/authdialog-strings.xml
+++ b/src/android/res/values/authdialog-strings.xml
@@ -760,24 +760,13 @@
       at a time.</string>
 
     <!-- Download History UI strings -->
-    <!-- Dialog title [CHAR LIMIT=25] -->
-    <string name="download_no_sdcard_dlg_title" product="nosdcard">USB storage unavailable</string>
     <!-- Dialog title -->
     <string name="download_no_sdcard_dlg_title" product="default">No SD card</string>
-    <!-- Dialog message [CHAR LIMIT=NONE] -->
-    <string name="download_no_sdcard_dlg_msg" product="nosdcard">USB storage is required to download <xliff:g id="filename">%s</xliff:g>.</string>
     <!-- Dialog message -->
     <string name="download_no_sdcard_dlg_msg" product="default">An SD card is required to download <xliff:g id="filename">%s</xliff:g>.</string>
     <!-- Title for a dialog informing the user that the SD card used for
-            external storage is busy so they cannot download anything [CHAR LIMIT=25] -->
-    <string name="download_sdcard_busy_dlg_title" product="nosdcard">USB storage unavailable</string>
-    <!-- Title for a dialog informing the user that the SD card used for
             external storage is busy so they cannot download anything -->
     <string name="download_sdcard_busy_dlg_title" product="default">SD card unavailable</string>
-    <!-- Message for a dialog informing the user that the SD card used for
-            external storage is busy so they cannot download anything.  Informs
-            the user how to enable SD card storage [CHAR LIMIT=NONE] -->
-    <string name="download_sdcard_busy_dlg_msg" product="nosdcard">The USB storage is busy. To allow downloads, touch Turn Off USB Storage in the notification.</string>
     <!-- Message for a dialog informing the user that the SD card used for
             external storage is busy so they cannot download anything.  Informs
             the user how to enable SD card storage -->


### PR DESCRIPTION
The `product="nosdcard"` lines threw errors at android compilation due to duplicate string occurrence.
The same issue is reported here:
https://github.com/MSOpenTech/cordova-plugin-auth-dialog/issues/5
in a similar project:
https://github.com/MSOpenTech/cordova-plugin-auth-dialog
and is fixed here
https://github.com/MSOpenTech/cordova-plugin-auth-dialog/commit/445d044987bab4d10df688f4b62f79162bf3bf69#diff-394fa09ff01ebd6b830d5202790d6fd1